### PR TITLE
feat: /mx:review — the headline review-grade command (Phase 2)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- **`/mx:review`** — the headline review command (Phase 2 of the reposition). Bundles all 8 review-grade agents into a single verdict (`PASS` / `PASS WITH WARNINGS` / `REJECT`) with per-agent findings and a recommendation. Read-only — it interrogates and reports, never modifies code.
+  - **Default scope** reviews everything that differs from trunk (`main`/`master`) — committed branch work *and* uncommitted changes, including untracked new files (where AI-generated code most often hides). Computed via merge-base, so it also works on trunk with only uncommitted edits. Flags: `--staged`, `--commit <sha>`, `--branch <name>`, `--scope <path>`.
+  - **Three configurable verdict modes**, default **balanced**: `--strict` (REJECT on CRITICAL or HIGH), balanced (REJECT on CRITICAL), `--advisory` (never blocks). Always prints a recommendation with reasons.
+  - **Models** — each agent keeps its existing model assignment (routing optimization deferred to the Phase 2.5 spike).
+  - Documented in `docs/` (new "Review (start here)" page, top of the Commands sidebar) and surfaced as the primary entry point in `/mx:help` and the README.
+
 ### Changed
 
 - **Repositioning** — mx-workflow now leads with its identity as "the review-grade quality layer for AI-generated code" rather than "a full dev-lifecycle plugin." Generation is table stakes; the differentiator is the refusal layer that interrogates AI-generated code for silent failures, hallucinated APIs, suppressed errors, and type rot. The full lifecycle toolkit stays — it's now framed as the foundation underneath the review agents. (Phase 1 of the reposition; see `ROADMAP.md`.)

--- a/README.md
+++ b/README.md
@@ -101,6 +101,7 @@ That is the core loop. For more complex workflows, see [Which Path Should I Use?
 Commands are invoked as `/mx:<command-name>`:
 
 ```
+/mx:review              # The headline: one verdict from all 8 review agents
 /mx:plan                # Create an implementation plan
 /mx:implement           # Execute plan with validation
 /mx:e2e                 # Browser-based E2E testing
@@ -219,6 +220,7 @@ Supporting cast for `/mx:build` and `/mx:build-with-agent-team` — they generat
 ## Which Path Should I Use?
 
 ```
+Review code (yours or AI) → /mx:review (one verdict from all 8 review agents)
 New session               → /mx:prime
 New feature (needs spec)  → /mx:prd → /mx:plan → /mx:implement
 Bug fix or small feature  → /mx:rca (if needed) → /mx:plan → /mx:implement

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -44,13 +44,14 @@ mx-workflow already has 8 review-grade agents (out of 12). The pivot is mostly *
 
 The single command that bundles all 8 review-grade agents into one verdict report. The "starter dose" — install + `/mx:review` = _"oh, I see what this is for."_
 
-- [ ] Spec `commands/review.md` — what it does, what it loads, the verdict format
-- [ ] Decide the verdict format (Pass / Warnings / Reject + per-agent findings)
-- [ ] Decide what code it runs on by default (unstaged diff? last commit? branch vs trunk?)
-- [ ] Implement: orchestrate the 8 review agents, collect findings, render the verdict
-- [ ] Test on at least 3 real repos (lehi31, koi-transportation, ward-page)
-- [ ] Document in `docs/`
-- [ ] Update `commands/help.md` to surface `/mx:review` as the primary entry point
+- [x] Spec `commands/review.md` — what it does, what it loads, the verdict format
+- [x] Decide the verdict format (Pass / Warnings / Reject + per-agent findings) — 3 configurable modes, default **balanced** (REJECT on CRITICAL; `--strict` adds HIGH; `--advisory` never blocks); always prints a recommendation with reasons
+- [x] Decide what code it runs on by default — everything differing from trunk (committed branch work + uncommitted + untracked), via merge-base; flags `--staged`/`--commit`/`--branch`/`--scope`
+- [x] Implement: orchestrate the 8 review agents, collect findings, render the verdict
+- [~] Test on at least 3 real repos (lehi31, koi-transportation, ward-page) — scope detection validated against all 3 (trunk + merge-base resolution correct); full verdict runs pending (repos are clean — needs changes to interrogate, or run on a live branch)
+- [x] Document in `docs/`
+- [x] Update `commands/help.md` to surface `/mx:review` as the primary entry point
+- Models: keep existing per-agent assignments (routing → Phase 2.5)
 
 ## Phase 3 — Review-tier commands
 
@@ -92,6 +93,7 @@ The trend in the Brief content over the last 40 days: _"Claude Skills are quietl
 
 ## Reference
 
+- **Evidence trail for this pivot:** [references/repositioning-evidence.md](references/repositioning-evidence.md) — direct quotes from mx-brief content (May 15 → June 24, 2026), organized by claim, with notes on what would update each decision.
 - Thesis blog post: [_I Built the Wrong Half_](https://joshtune.com/posts/i-built-the-wrong-half) (draft on joshtune.com — to publish before Phase 2 ships)
 - Triggering market signal: [Claude Tag launch (June 23, 2026)](https://www.anthropic.com/news/introducing-claude-tag)
 - Adjacent trend: [Claude Code Dynamic Workflows GA (June 10, 2026)](https://claude.com/) — nested subagents, depth=5

--- a/commands/help.md
+++ b/commands/help.md
@@ -11,6 +11,12 @@ MX-WORKFLOW COMMANDS
 
 All commands use the /mx: prefix (e.g., /mx:plan, /mx:commit).
 
+START HERE — REVIEW-GRADE QUALITY
+  /mx:review [--strict | --advisory] [--staged | --branch <name>]
+                                       Bundle the 8 review agents into ONE verdict
+                                       (Pass / Warnings / Reject) on your changes vs trunk.
+                                       The refusal layer — interrogates AI-generated code.
+
 SESSION START
   /mx:prime                            Warm up codebase context (reads key files, runs checks)
   /mx:context-prime <path> [--learn] [--recursive]
@@ -73,6 +79,7 @@ ANYTIME
   /mx:shipit [desc]                      Fix + check + commit + push in one step
 
 WHICH PATH SHOULD I USE?
+  Review code (yours or AI) → /mx:review (one verdict from all 8 review agents)
   New session               → /mx:status (check project readiness) → /mx:prime (warm up context)
   Idea to shipped code      → /mx:build "your idea" (asks questions, then does everything)
   New feature (needs spec)  → /mx:prd → /mx:plan → /mx:implement

--- a/commands/review.md
+++ b/commands/review.md
@@ -1,0 +1,141 @@
+---
+description: "Review-grade verdict on your code — bundles the 8 review agents into one Pass / Warnings / Reject report"
+argument-hint: "[--strict | --advisory] [--staged | --commit <sha> | --branch <name>] [--scope <path>]"
+allowed-tools: ["Bash", "Glob", "Grep", "Read", "Write", "Task"]
+---
+
+# Review
+
+The headline review command. Bundles all 8 review-grade agents into a single verdict on your changes: **PASS**, **PASS WITH WARNINGS**, or **REJECT**, with per-agent findings and a recommendation.
+
+This is the refusal layer — it interrogates code (yours or an AI's) and pushes back on silent failures, hallucinated APIs, suppressed errors, weak types, missing tests, and unjustified shortcuts. It is **read-only**: it reports and recommends, it never modifies code.
+
+**Options:** $ARGUMENTS
+
+## Flags
+
+| Flag | Effect |
+|------|--------|
+| (none) | Review everything that differs from trunk — committed branch work **and** uncommitted changes |
+| `--staged` | Review only staged changes (`git diff --cached`) |
+| `--commit <sha>` | Review a single commit's diff (`git show <sha>`) |
+| `--branch <name>` | Compare against an explicit base branch instead of auto-detected trunk |
+| `--scope <path>` | Limit the review to a directory or file |
+| `--strict` | **Mode 1** — REJECT on any CRITICAL **or** HIGH finding |
+| (default) | **Mode 2 (balanced)** — REJECT on CRITICAL; HIGH becomes a warning |
+| `--advisory` | **Mode 3** — never REJECT; report all findings labeled by severity |
+
+## Step 1: Determine Scope
+
+Compute the set of changed files. Default behavior reviews **all changes relative to trunk**, so it works whether you're mid-branch or just have uncommitted edits.
+
+1. **Detect trunk.** Use `--branch <name>` if given. Otherwise pick the first that exists: `main`, then `master` (`git rev-parse --verify <name>`). If neither exists, fall back to reviewing uncommitted changes only.
+
+2. **Resolve the base** (unless a scoping flag overrides):
+   - Default: `BASE=$(git merge-base HEAD <trunk>)`. Then the review set is `git diff --name-only $BASE` — this captures committed-on-branch changes **and** the working tree (staged + unstaged). When you're sitting on trunk itself, the merge-base is `HEAD`, so this naturally reduces to just your uncommitted changes.
+   - `--staged`: review set is `git diff --cached --name-only`.
+   - `--commit <sha>`: review set is `git show --name-only --format= <sha>`.
+   - `--branch <name>`: same as default but with the given base.
+
+3. **Include untracked files.** `git diff` ignores new files that were never added — and brand-new files are the most common shape of AI-generated code. For the default and `--branch` cases, add `git ls-files --others --exclude-standard` (respecting `--scope`) to the review set so whole new modules don't slip through unreviewed. (`--staged` and `--commit` cases don't need this — those sets are explicit.)
+
+4. **Apply `--scope <path>`** if present — filter the review set to files under that path.
+
+5. Capture the actual content for the review set: `git diff $BASE -- <tracked files>` plus the full text of any untracked files. Agents review this, not the whole repo.
+
+If the review set is empty, tell the user there's nothing to review and stop.
+
+## Step 2: Classify What Changed
+
+Inspect the diff so you only spend agents where they apply:
+
+- **Types/interfaces touched?** (new or modified `type`/`interface`/`struct`/`class`/`enum` declarations) → run type-design analysis
+- **Test files touched?** (`*.test.*`, `*.spec.*`, `*_test.*`, `e2e/`, `tests/`) → run test analysis
+- **Comments/docstrings touched?** → run comment analysis
+
+The four always-on agents run regardless.
+
+## Step 3: Run the Review Agents (in parallel)
+
+Invoke the review-grade agents via the Task tool. Pass each agent the diff and the list of changed files as scope. Launch them concurrently — they are independent and read-only.
+
+**Always run:**
+- **mx-code-reviewer** — bugs, CLAUDE.md guideline violations, logic/null/race issues (reports issues scoring ≥80)
+- **mx-silent-failure-hunter** — empty catches, swallowed errors, inappropriate fallbacks, mock code in production paths
+- **mx-performance-auditor** — algorithmic complexity, N+1s, memory and render hot paths
+- **mx-quality-keeper** — orchestrates structural checks (lint, type-check, tests via `/mx:validate`; suppressions via `/mx:check-ignores`) and reports pass/fail
+
+**Run if applicable (from Step 2):**
+- **mx-type-design-analyzer** — if types/interfaces changed
+- **mx-mr-test-analyzer** — if test files changed
+- **mx-comment-analyzer** — if comments/docstrings changed
+
+**Always run last, in suggest-only mode:**
+- **mx-code-simplifier** — runs in **report-only** mode for this command: surface simplification opportunities as findings (severity INFO). **It must NOT modify any files here** — `/mx:review` is read-only. Direct the user to `/mx:implement` or `/mx:simplify` to apply.
+
+Each agent returns its findings with severity. Normalize severities to a common scale:
+
+| Normalized | Maps from |
+|-----------|-----------|
+| CRITICAL | severity CRITICAL, or confidence ≥ 90 |
+| HIGH | severity HIGH / IMPORTANT, or confidence ≥ 80 |
+| MEDIUM | severity MEDIUM, criticality 5–6 |
+| INFO | INFO, simplifier suggestions, nice-to-haves |
+
+## Step 4: Compute the Verdict
+
+Pick the threshold from the mode flag (default **balanced**):
+
+| Mode | Flag | REJECT when | WARNINGS when |
+|------|------|-------------|---------------|
+| 1 — strict | `--strict` | any CRITICAL **or** HIGH finding | (n/a — HIGH already rejects) MEDIUM/INFO present |
+| 2 — balanced *(default)* | none | any CRITICAL finding | any HIGH finding (no CRITICAL) |
+| 3 — advisory | `--advisory` | never | any finding present |
+
+Verdict resolution:
+- **REJECT** — threshold for the active mode is met.
+- **PASS WITH WARNINGS** — no REJECT trigger, but warnings exist.
+- **PASS** — no findings above INFO.
+
+**Always produce a recommendation with reasons**, regardless of mode — e.g. "Reject: the auth fallback in `auth.ts:42` silently grants access on token-parse failure; fix before merge." In advisory mode, still state what the verdict *would be* under balanced mode so the signal isn't lost.
+
+## Step 5: Report
+
+Save the full report to `.agents/reports/review-{YYYY-MM-DD}.md` (create the directory if needed; if a report already exists for today, append a `-2`, `-3` suffix).
+
+Display a terminal summary:
+
+```
+MX REVIEW
+=========
+Scope:      <e.g. branch vs main — committed + uncommitted>
+Base:       <trunk> @ <merge-base sha>
+Mode:       balanced
+Files:      <N> changed
+
+VERDICT:    PASS / PASS WITH WARNINGS / REJECT
+
+Recommendation:
+  <one or two sentences — what to do and why, citing the strongest findings>
+
+AGENT FINDINGS
+──────────────
+mx-code-reviewer         <PASS | N findings: X critical, Y high, Z info>
+mx-silent-failure-hunter <…>
+mx-performance-auditor   <…>
+mx-quality-keeper        <lint/types/tests: PASS|FAIL · suppressions: N>
+mx-type-design-analyzer  <… | not run (no type changes)>
+mx-mr-test-analyzer      <… | not run (no test changes)>
+mx-comment-analyzer      <… | not run (no comment changes)>
+mx-code-simplifier       <N suggestions (report-only)>
+
+TOP FINDINGS
+────────────
+[CRITICAL] <file:line> — <what's wrong> (mx-silent-failure-hunter)
+[HIGH]     <file:line> — <what's wrong> (mx-code-reviewer)
+[INFO]     <file:line> — <suggestion> (mx-code-simplifier)
+
+File: .agents/reports/review-{date}.md
+```
+
+Only list agents that actually ran with results; mark conditional agents that were skipped as "not run (reason)". Keep the terminal output focused — full per-finding detail lives in the saved report.

--- a/docs/astro.config.mjs
+++ b/docs/astro.config.mjs
@@ -29,6 +29,7 @@ export default defineConfig({
         {
           label: 'Commands',
           items: [
+            { label: 'Review (start here)', slug: 'commands/review' },
             { label: 'Session & Discovery', slug: 'commands/session-discovery' },
             { label: 'Implementation', slug: 'commands/implementation' },
             { label: 'Multi-Agent', slug: 'commands/multi-agent' },

--- a/docs/src/content/docs/commands/review.mdx
+++ b/docs/src/content/docs/commands/review.mdx
@@ -1,0 +1,56 @@
+---
+title: Review
+description: The headline review command — bundles the 8 review-grade agents into one Pass / Warnings / Reject verdict.
+---
+
+`/mx:review` is the starter dose. Run it on any changes and it bundles all eight review-grade agents into a **single verdict** — `PASS`, `PASS WITH WARNINGS`, or `REJECT` — with per-agent findings and a recommendation you can act on.
+
+It's the refusal layer in one command: it interrogates code (yours or an AI's) and pushes back on silent failures, hallucinated APIs, suppressed errors, weak types, missing tests, and unjustified shortcuts. It is **read-only** — it reports and recommends, it never modifies your code.
+
+## /mx:review
+
+**Review-grade verdict on your changes**
+
+```
+/mx:review [--strict | --advisory] [--staged | --commit <sha> | --branch <name>] [--scope <path>]
+```
+
+By default it reviews **everything that differs from trunk** — both your committed branch work and your uncommitted changes (including brand-new untracked files, which is where AI-generated code most often hides). Because the scope is computed from the merge-base with `main`/`master`, it also does the right thing when you're sitting on trunk with just uncommitted edits.
+
+**When to use it:**
+
+- Before opening a PR — get a verdict on the whole branch
+- After Claude (or Cursor, Copilot, Claude Tag…) generates a chunk of code, to interrogate it
+- Any time you want a fast, opinionated quality read on your changes
+
+### The agents it runs
+
+Always: `mx-code-reviewer`, `mx-silent-failure-hunter`, `mx-performance-auditor`, `mx-quality-keeper` (structural checks). Conditionally: `mx-type-design-analyzer` (if types changed), `mx-mr-test-analyzer` (if tests changed), `mx-comment-analyzer` (if comments changed). Finally `mx-code-simplifier` runs in **report-only** mode — it surfaces simplification suggestions but never edits files here.
+
+### Verdict modes
+
+The verdict format is always Pass / Warnings / Reject plus per-agent findings. What flips it to REJECT is configurable:
+
+| Mode | Flag | REJECT when |
+|------|------|-------------|
+| Strict | `--strict` | any CRITICAL **or** HIGH finding |
+| **Balanced** *(default)* | *(none)* | any CRITICAL finding (HIGH → warning) |
+| Advisory | `--advisory` | never blocks — labels findings by severity |
+
+Whatever the mode, the report **always includes a recommendation with reasons** — and in advisory mode it still tells you what the verdict *would* be under balanced rules, so the signal is never lost.
+
+### Scope flags
+
+| Flag | Effect |
+|------|--------|
+| *(none)* | Committed branch work **and** uncommitted changes vs trunk |
+| `--staged` | Only staged changes |
+| `--commit <sha>` | A single commit's diff |
+| `--branch <name>` | Compare against an explicit base branch |
+| `--scope <path>` | Limit to a directory or file |
+
+### Output
+
+A terminal summary with the verdict, a per-agent findings table, and the top findings by severity. The full report is saved to `.agents/reports/review-{YYYY-MM-DD}.md`.
+
+> **`/mx:review` vs `/mx:qa`** — `/mx:review` is the headline interrogation: all eight review agents, one verdict, tuned for "is this code good enough to merge?" `/mx:qa` is the deeper structural + spec-conformance audit (suppressions, dependencies, contract and requirement verification) best run after a feature or team build. Reach for `/mx:review` constantly; reach for `/mx:qa --full` at milestones.

--- a/references/repositioning-evidence.md
+++ b/references/repositioning-evidence.md
@@ -1,0 +1,161 @@
+# Repositioning Evidence — Brief Signal Behind the Review-Grade Pivot
+
+_Why this doc exists: the [ROADMAP](../ROADMAP.md) repositions mx-workflow from "full dev lifecycle plugin" to "review-grade quality layer for AI-generated code." That's a meaningful claim. This is the source data — direct quotes from the daily Brief content (May 15 → June 24, 2026) that the pivot is built on, organized by the specific claim each piece of evidence supports._
+
+_Recorded so future-me (or anyone reading the ROADMAP) can audit the decision rather than take it on faith._
+
+---
+
+## Methodology
+
+- **Source:** [mx-brief](https://joshtune.github.io/mx-brief) daily summaries, scraped from a curated set of YouTube channels, Anthropic/Claude release feeds, Boris Cherny's Twitter, OpenAI/Sam Altman, and a handful of AI-focused commentators.
+- **Sample:** 1,325 items indexed total. 468 from the last 40 days (since 2026-05-15). 216 of those are tagged dev/agent-relevant.
+- **Author bias to flag:** I (joshtune) curated the source list. So the data is biased toward _the AI-coding world I was already paying attention to_. Use the items as triangulation, not proof.
+
+---
+
+## Claim 1 — Anthropic is shipping into the Slack-agent space mx-workflow occupies
+
+**Evidence:**
+
+- **2026-06-23 · Anthropic (official launch):** _"Introducing Claude Tag, a new way for teams to work with Claude. In Slack, Claude joins as a team member with access to the channels and tools you choose. Tag Claude in and delegate tasks to it while you focus on other work."_ ([source](https://www.anthropic.com/news/introducing-claude-tag))
+- **2026-06-23 · @claudeai:** _"Claude Tag is an evolution of Claude Code, made more proactive and built to work with a full team. It's now one of the main ways we get things done at Anthropic: 65% of our product team's code now comes from our internal version."_
+- **2026-06-23 · @bcherny:** _"Tag Claude in a channel, it spins up an instance with its own sandbox. It clones repos, writes code, tests, compiles all in that isolated environment and the sandbox gets thrown away when it's done. One instance per thread, its own memory and permissions per channel."_
+- **2026-06-23 · @bcherny:** _"Claude is really proactive with Claude Tag. You don't need to prompt it to do work, it can do work proactively based on your instructions. It has excellent memory and access to your data, so it can behave differently per channel."_
+
+**What this supports in the ROADMAP:** the mx-workflow Slack bot is no longer differentiated by the integration shape. The opportunity cost of competing on _"Claude in Slack with per-channel memory and sandboxed work"_ went up sharply this week.
+
+---
+
+## Claim 2 — Native primitives are absorbing things mx-workflow used to handle
+
+**Evidence:**
+
+- **2026-06-09 · @bcherny (nested subagents went GA):** _"Just landed nested subagent support in Claude Code. Starting to experiment more with agents kicking off agents as a way to better manage context. Capped at depth=5 to start, going out in today's release."_
+- **2026-06-10 · @claudeai (Dynamic Workflows GA):** _"Dynamic workflows in Claude Code are now generally available. For complex tasks like codebase-wide bug hunts, Claude writes its own orchestration and runs subagents in parallel, verifying the work before it reaches you."_
+- **2026-06-16 · Claude Code (Week 24 release notes):** _"Ultraplan, Monitor tool, /autofix-pr from CLI. Four major features that change how you work: cloud-based planning that frees your terminal, a background watcher that reacts to events in real-time, PR auto-fix from the CLI, and a team onboarding generator."_
+- **2026-06-18 · @claudeai (Artifacts):** _"New in Claude Code: Artifacts. Interactive pages built from your session, like a PR walkthrough or a living project dashboard, shared with your team at a private link. Available in beta on Team and Enterprise plans."_
+
+**What this supports in the ROADMAP:** mx-workflow shouldn't try to parallel orchestration, monitoring, or artifact-publishing — Claude Code now ships native versions. The play is to **compose with these primitives** (e.g., mx review agents callable from native dynamic workflows; `/mx:review` triggerable via Monitor) rather than build alongside them.
+
+---
+
+## Claim 3 — Marketplace momentum is overwhelmingly generative
+
+**Evidence:**
+
+- **2026-05-27 · @claudeai (marketplace expansion):** _"New in the Claude Marketplace: @augmentcode, @boltdotnew, @coderabbitai, @hebbia, and @WeAreLegora. Apply your existing Anthropic spend commitment toward their Claude-powered products."_
+  - Of those five: Augmentcode (generation), Bolt.new (generation), Hebbia (generation), Legora (generation). Only **CodeRabbit** is review-grade. So the most prominent marketplace shipment in the period was 4 generators : 1 reviewer.
+- **2026-05-26 · RT by @bcherny (security plugin):** _"We've shipped a security-guidance plugin for Claude Code that helps identify and fix vulnerabilities as you're writing code. Available for all Claude Code users. Install from the plugin marketplace (/plugins)."_
+  - Note: this **is** a refusal-style plugin. The exception that proves the rule — Anthropic themselves shipped it, indicating they see the gap too.
+- **2026-06-16 · @AnthropicAI:** _"The average task in Claude Code has grown more valuable. We compared the type of work done in each session to what that same task would cost on a freelance marketplace. From October to April, the monetary value of the average session grew 27%."_
+  - Anthropic's framing of value is the freelance market — i.e., paid for _generating_ things. The framing itself signals where the industry is pricing value.
+
+**What this supports in the ROADMAP:** there's an actual gap in the marketplace. Almost everything new is a generator. The exceptions (security-guidance, CodeRabbit) confirm refusal-style tools are real but rare. mx-workflow's 8 review-grade agents are a differentiated position.
+
+**Limitation to flag:** I scanned what showed up in Brief, not the full marketplace. There may be more review plugins than I saw — recommend doing a manual marketplace audit before Phase 4 (rewriting the marketplace listing).
+
+---
+
+## Claim 4 — Skills are emerging as a productizable tier separate from plugins
+
+**Evidence:**
+
+- **2026-06-23 · mx-brief daily summary:** _"Claude Skills are quietly becoming a business model while Codie Sanchez hammers that decisiveness — not hustle — is what actually prints money."_
+- **2026-06-22 · Nate Herk (post):** _"Turn Claude skills into income as an AI consultant. — It reframes 'knowing Claude' as a fast-decaying asset and argues the durable, high-paying move is diagnosing what to build."_
+- **2026-06-18 · @claudeai (Artifacts launch references):** _"Artifacts draw on the full context of your session: codebase, plugins, skills, connected tools."_ — Skills are listed as a peer of plugins and tools in Anthropic's own framing.
+
+**What this supports in the ROADMAP (Phase 5):** publishing individual mx review agents as standalone Claude Skills is a real distribution play. Skills are smaller, more focused, individually installable — and the trend talk treats them as their own product tier.
+
+**Limitation to flag:** "becoming a business model" is one mx-brief summary's claim, not yet a market-scale signal. Treat Phase 5 as exploratory rather than load-bearing.
+
+---
+
+## Claim 5 — Generation is getting cheaper and more commoditized (model routing)
+
+**Evidence:**
+
+- **2026-06-24 · @nutlope (GLM Arena tests):** _"On average, GLM 5.2 produced 2x the tokens but was still faster + 3x cheaper with similar quality."_
+- **2026-06-24 · RT by @nutlope (Together):** _"A tangible comparison of GLM performance stacked against Opus 4.8 on web tasks by @nutlope. GLM 5.2 is chattier, but still faster when served by @togethercompute and over 3x cheaper."_
+- **2026-06-22 · @nutlope (blind A/B):** _"Introducing The Blind Test. Two landing pages. One built by GLM 5.2 and one by Opus 4.8. Can you tell which is which?"_ — Outcome reported June 23: humans guessed wrong ~50% of the time, _"basically a coin flip."_
+- **2026-06-19 · Nate Herk:** _"Running GLM 5.2 inside Claude Code as a cheap Opus alternative. GLM 5.2 handles ~80% of coding tasks at roughly 5x lower cost than Opus inside the same Claude Code harness — a practical lesson in model-per-task routing."_
+- **2026-06-24 · Anthropic (Sonnet 4.6 / Opus 4.6):** _"Opus 4.6 is the model powering your Claude Code right now — Sonnet 4.6 is the cost-effective option for any API-driven features you build."_ — Anthropic now explicitly markets cost-tiering.
+
+**What this supports in the ROADMAP:** generation quality is converging across cheaper models. The differentiator can't be _"we generate well"_ — that's now a $0.03 commodity. Differentiation has to be in the layer above.
+
+**Cross-implication (open question in ROADMAP):** mx-workflow should add a per-command `model:` field so `/mx:commit` can use a cheap model while `/mx:review` stays on Opus.
+
+---
+
+## Claim 6 — Long-running autonomous coding is the new design target
+
+**Evidence:**
+
+- **2026-06-08 · @bcherny:** _"Seeing a number of benchmarks showing Opus is the best model for long-running work. Five tips for running Opus autonomously for hours/days: 1. Use auto mode for permissions, so Claude doesn't ask for approval. 2. Use dynamic workflows, to have Claude orchestrate hundreds/thousands of agents to get work done…"_
+- **2026-06-11 · Matt Wolfe:** _"Anthropic's new Fable 5 model… Fable 5 is pitched as a set-and-forget model for huge, grindy coding jobs — the kind of long-running refactors and migrations that eat your web app maintenance time."_
+- **2026-06-09 · @bcherny:** _"Fable 5 is the biggest step up I've felt in our models since Opus 4.5 back in November. After 4.5 came out I uninstalled my IDE when I realized that I'd been doing 100% of my coding in a terminal for a few weeks. With Fable, it's felt like…"_
+
+**What this supports in the ROADMAP:** if AI is going to run unattended for hours generating code, _the cost of an undetected silent failure goes way up._ A review-grade quality layer becomes a safety belt, not a luxury. Strengthens the strategic case for refusal-focused tooling.
+
+---
+
+## Claim 7 — Security/sandboxing is a loud and sustained focus
+
+**Evidence:**
+
+- **76 items** in the last 40 days matched security/sandbox patterns. The recurring release-note string across June 18–24:
+  - **2026-06-18 to 2026-06-24 · claude-code releases (v2.1.183, .185, .186, .187, .190, .191):** _"Security hardening, Vertex AI wizard, Monitor tool. Major Bash permission security fixes — if you use auto-permissions or bypass mode, update immediately."_
+- **2026-06-23 · @bcherny on Claude Tag security:** _"We've worked hard to make it secure at every level. 1/ At the model training stage, 2/ the classifiers on top of our models and things like auto mode, 3/ we protect what Claude has access to (websites it can access and it can't see the credential secrets it uses)…"_
+
+**What this supports in the ROADMAP:** the marketplace and the platform are both moving aggressively to harden permissions on bash + auto-execution. Any plugin that exec's bash (mx-workflow does, extensively) needs a permission audit. Also creates a strategic opportunity: `/mx:security-audit` as a contribution back to the marketplace, aligned with the same review-grade framing.
+
+**This is a tactical signal, not a strategic one** — it doesn't move the pivot direction, but it does change what should be high-priority cleanup before Phase 2 ships.
+
+---
+
+## Claim 8 — Portable memory is the emerging shape of agent infrastructure
+
+**Evidence:**
+
+- **2026-06-19 · Cole Medin (post):** _"Portable, encrypted AI memory shared across coding agents. — If you're juggling Claude Code, Codex, and other agents, this shows how to stop re-teaching each one your context by putting memory in a tool-agnostic MCP layer — directly relevant to how you'd architect mx-workflow's memory."_
+- **2026-06-20 · mx-brief daily summary:** _"Governments are banning AI models while the smart money quietly builds portable memory, deeper specialties, and side hustles to cash in when the dust settles."_
+- **2026-06-23 · @bcherny on Claude Tag memory:** _"It has excellent memory and access to your data, so it can behave differently per channel."_
+
+**What this supports in the ROADMAP:** weak signal (only 2 substantive items). Worth tracking, not yet worth building toward. Captured as a Phase 5+ idea: expose mx-workflow's project context as an MCP server so future Claude Tag instances + Codex + other tools can read it without re-priming.
+
+---
+
+## Composite case for the pivot
+
+Taken together:
+
+1. **The Slack-agent shape is no longer mx-workflow's edge** (Claim 1).
+2. **Native primitives now do orchestration, monitoring, and artifact publishing** (Claim 2).
+3. **The marketplace is overwhelmingly generative, with a visible refusal gap** (Claim 3).
+4. **Generation quality is commoditizing across cheaper models** (Claim 5).
+5. **Long-running autonomy raises the cost of undetected failures** (Claim 6).
+6. **mx-workflow already has 8 review-grade agents** — so the pivot is _structural realignment_, not _new feature surface_.
+
+The argument is not _"Claude Tag is great, therefore pivot."_ It's _"the entire industry is racing toward cheaper, faster, more autonomous generation — and mx-workflow's existing strength happens to be in the layer that becomes more valuable as that race progresses."_
+
+---
+
+## What would update this decision
+
+The pivot is robust to most surface changes (Claude Tag flopping, GLM losing momentum, etc.). It is NOT robust to these specific signals — watch for them in future Briefs:
+
+- **Another major plugin or platform ships a review-agent team.** This would commoditize the layer mx-workflow is aiming for. Action: narrow the claim (specialize on a sub-domain — e.g., type-design review specifically) rather than reverse.
+- **Claude or another model starts reliably refusing its own bad output.** This collapses the gap between generation and verification. Action: re-evaluate whether mx review agents have a durable home.
+- **The marketplace tilts toward refusal-style plugins (3+ per quarter).** The differentiation thins. Action: lean harder on integration/UX rather than the underlying claim.
+- **Generation stops getting cheaper.** Removes the cost pressure that makes verification economically interesting. Less likely, but worth flagging.
+
+mx-brief should catch any of these within days. The agreement with myself: revisit this doc quarterly, mark each claim as _"still holds"_ / _"weakened"_ / _"reversed"_ with evidence.
+
+---
+
+## Companion documents
+
+- [ROADMAP.md](../ROADMAP.md) — the actual phased work plan informed by this evidence
+- Public thesis post: [_I Built the Wrong Half_](https://joshtune.com/posts/i-built-the-wrong-half) — the personal-voice version of this case, written for the joshtune.com audience
+
+_Doc created: 2026-06-25. Next review: 2026-09-25._


### PR DESCRIPTION
## What

Phase 2 of the reposition (`ROADMAP.md`): the headline **`/mx:review`** command. Install the plugin, run `/mx:review`, and you immediately get what mx-workflow is for — one verdict from all 8 review-grade agents.

It bundles the agents into a single **PASS / PASS WITH WARNINGS / REJECT** verdict with per-agent findings and a recommendation. **Read-only** — it interrogates and reports, never modifies code.

## Key decisions (settled with the maintainer)

| Decision | Choice |
|---|---|
| **Default scope** | Everything differing from trunk — committed branch work **and** uncommitted changes, **including untracked new files** (where AI-generated code most often hides). Computed via `merge-base`, so it also works on trunk with only uncommitted edits. Flags: `--staged`, `--commit <sha>`, `--branch <name>`, `--scope <path>`. |
| **Verdict** | 3 configurable modes, default **balanced** (REJECT on CRITICAL; `--strict` also rejects HIGH; `--advisory` never blocks). Always prints a recommendation with reasons. |
| **Models** | Each agent keeps its existing assignment; routing optimization deferred to the Phase 2.5 spike. |

## Changes

- **`commands/review.md`** — the command spec: scope resolution, agent orchestration (4 always-on + 3 conditional + simplifier in report-only mode), severity normalization, verdict computation, and report format
- **`docs/`** — new "Review (start here)" page, pinned to the **top of the Commands sidebar**; includes a `/mx:review` vs `/mx:qa` comparison
- **`commands/help.md`** + **`README.md`** — surface `/mx:review` as the primary entry point
- **CHANGELOG** `[Unreleased]` entry
- **ROADMAP** Phase 2 checkboxes ticked
- **`references/repositioning-evidence.md`** — the paper trail linked from the ROADMAP (keeps that link from dangling)

## Testing

Scope detection was smoke-tested against all three target repos (lehi31, koi-transportation, ward-page) — trunk and merge-base resolution resolve correctly. A gap the test surfaced and I fixed: `git diff` misses untracked files, so the command explicitly folds in `git ls-files --others --exclude-standard`. Full end-to-end verdict runs are pending — those repos are currently clean (nothing to interrogate); the command runs on live changes.

## Excluded

The unrelated local `CLAUDE.md` edit (orchestration dev notes) is left out to keep this PR focused.

## Not done / next

- Docs build not run locally (needs `npm install` in `docs/`).
- Phase 3 is the deeper review-tier commands (`/mx:hallucination-check`, `/mx:second-look`, `/mx:reject`, `/mx:ratchet`, `/mx:audit`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)